### PR TITLE
QT datadir fix

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -247,6 +247,8 @@ int main(int argc, char *argv[])
 
         boost::thread_group threadGroup;
 
+	SelectParamsFromCommandLine();
+	//ALERT: BitcoinGUI initializes the chain, and since AppInit2 hasn't been called yet, GetDataDir() doesn't know which ChainParams to use. Workaround is to call SelectParamsFromCommandLine() earlier
         BitcoinGUI window;
         guiref = &window;
 


### PR DESCRIPTION
Enable the QT to know it is using testnet before starting the splash screen (which loads and writes the blockchain before command line parameters are parsed)